### PR TITLE
Produce an informative error message if the local timezone cannot be determined

### DIFF
--- a/parse/parser.ml
+++ b/parse/parser.ml
@@ -1504,7 +1504,14 @@ let hms_t_of_ast (ast : ast) : (Timere.hms, string) CCResult.t =
   | Tokens [ (_, _, Hms hms) ] -> Ok hms
   | _ -> Error "Unrecognized pattern"
 
-let parse_date_time ?(tz = CCOpt.get_exn @@ Timere.Time_zone.local ()) s =
+let get_local_tz () =
+  let tz = Timere.Time_zone.local () in
+  match tz with
+  | Some tz -> tz
+  | None -> raise (Invalid_argument "Could not determine the local timezone. \
+     Please specify ~tz explicitly or use an appropriate timere.tzlocal.* module")
+
+let parse_date_time ?(tz = get_local_tz ()) s =
   match parse_into_ast s with
   | Error msg -> Error msg
   | Ok ast -> (


### PR DESCRIPTION
There are situations when the user will get a generic `Invalid_argument "CCOpt.get_exn"` error message when trying to use `Timere_parse.date_time`, and it will be impossible to debug without reading the source.

```
utop # #require "timere.tzdb.none";;
utop # #require "timere.tzlocal.none";;
utop # #require "timere-parse";;

utop # Timere_parse.date_time "1970-01-01 00:00";;
Exception: Invalid_argument "CCOpt.get_exn".
```

This patch attaches a (hopefully) helpful error message to `Invalid_argument`.