### PR TITLE
Using oseq 0.5 in timere

### DIFF
--- a/debug/main.ml
+++ b/debug/main.ml
@@ -241,8 +241,8 @@ let debug_fuzz_pattern_intervals () =
           | Seq.Nil -> true
           | Seq.Cons (xr2, _) ->
             if
-              OSeq.mem ~eq:( = ) (x1, xr2) s
-              && OSeq.mem ~eq:( = ) (xr2, Timedesc.Span.succ xr2) s'
+              OSeq.mem ( = ) (x1, xr2) s
+              && OSeq.mem ( = ) (xr2, Timedesc.Span.succ xr2) s'
             then true
             else (
               print_endline
@@ -308,7 +308,7 @@ let debug_fuzz_union () =
   print_endline "=====";
   display_intervals ~display_using_tz:tz s;
   print_endline "=====";
-  Printf.printf "%b\n" (OSeq.equal ~eq:( = ) s s')
+  Printf.printf "%b\n" (OSeq.equal ( = ) s s')
 
 let debug_fuzz_pattern () =
   let tz_count = List.length Timedesc.Time_zone.available_time_zones in
@@ -392,7 +392,7 @@ let debug_fuzz_pattern () =
               |> Int_set.to_seq
               |> Seq.map (fun mday ->
                   if mday < 0 then day_count + mday + 1 else mday)
-              |> OSeq.mem ~eq:( = ) (Timedesc.day dt)
+              |> OSeq.mem ( = ) (Timedesc.day dt)
             in
             let wday_is_fine =
               Weekday_set.is_empty pattern.weekdays

--- a/dune-project
+++ b/dune-project
@@ -145,7 +145,7 @@ Features:
     (bisect_ppx (and :dev (>= "2.5.0")))
     dune
     seq
-    (oseq (>= "0.3"))
+    (oseq (>= "0.5"))
     (containers (>= "3.6"))
     fmt
     (timedesc (>= "1.1.0"))
@@ -177,7 +177,7 @@ Features:
     (ocaml (>= "4.08"))
     (bisect_ppx (and :dev (>= "2.5.0")))
     dune
-    (oseq (>= "0.3"))
+    (oseq (>= "0.5"))
     (re (>= "1.9.0"))
     (containers (>= "3.6"))
     (timedesc (>= "0.8.0"))

--- a/fuzz/inter_is_sound_and_complete.ml
+++ b/fuzz/inter_is_sound_and_complete.ml
@@ -12,7 +12,7 @@ let () =
           |> Time.Intervals.Inter.inter_multi_seq
           |> Time.slice_valid_interval
         in
-        let r = OSeq.equal ~eq:Time.Interval'.equal s s' in
+        let r = OSeq.equal Time.Interval'.equal s s' in
         if not r then
           Crowbar.fail
             (Fmt.str "tz: %s, times: %a\n"

--- a/fuzz/inter_order_does_not_matter.ml
+++ b/fuzz/inter_order_does_not_matter.ml
@@ -8,7 +8,7 @@ let () =
         let t2 = Time.inter l2 in
         let r1 = CCResult.get_exn @@ Resolver.resolve t1 in
         let r2 = CCResult.get_exn @@ Resolver.resolve t2 in
-        let r = OSeq.equal ~eq:Time.Interval'.equal r1 r2 in
+        let r = OSeq.equal Time.Interval'.equal r1 r2 in
         if not r then
           Crowbar.fail
             (Fmt.str "rand: %d, l1: %a\nl2: %a\n" rand

--- a/fuzz/pattern_intervals_is_complete.ml
+++ b/fuzz/pattern_intervals_is_complete.ml
@@ -37,14 +37,14 @@ let () =
                with
                | Seq.Nil -> true
                | Seq.Cons (xr2, _) ->
-                 OSeq.mem ~eq:Time.Interval'.equal (x1, xr2) r1
-                 && OSeq.mem ~eq:Time.Interval'.equal
+                 OSeq.mem Time.Interval'.equal (x1, xr2) r1
+                 && OSeq.mem Time.Interval'.equal
                    (x1, Timedesc.Span.succ xr2)
                    r2
-                 && OSeq.mem ~eq:Time.Interval'.equal
+                 && OSeq.mem Time.Interval'.equal
                    (x1, Timedesc.Span.succ x1)
                    r3
-                 && OSeq.mem ~eq:Time.Interval'.equal
+                 && OSeq.mem Time.Interval'.equal
                    (xr2, Timedesc.Span.succ xr2)
                    r4)
             s1

--- a/fuzz/pattern_intervals_is_sound.ml
+++ b/fuzz/pattern_intervals_is_sound.ml
@@ -30,22 +30,22 @@ let () =
         let r =
           OSeq.for_all
             (fun (x, y) ->
-               OSeq.mem ~eq:( = ) x s1
-               && OSeq.mem ~eq:( = ) y s2
+               OSeq.mem ( = ) x s1
+               && OSeq.mem ( = ) y s2
                && Timedesc.Span.(y - x <= bound)
                && not (OSeq.exists Timedesc.Span.(fun x2 -> x < x2 && x2 < y) s2))
             r1
           && OSeq.for_all
             (fun (x, y) ->
-               OSeq.mem ~eq:( = ) x s1
-               && OSeq.mem ~eq:( = ) (Timedesc.Span.pred y) s2
+               OSeq.mem ( = ) x s1
+               && OSeq.mem ( = ) (Timedesc.Span.pred y) s2
                && Timedesc.Span.(Timedesc.Span.pred y - x <= bound)
                && not
                  (OSeq.exists Timedesc.Span.(fun x2 -> x < x2 && x2 <= y) s2))
             r2
           && OSeq.for_all
             (fun (x, y) ->
-               y = Timedesc.Span.succ x && OSeq.mem ~eq:Timedesc.Span.equal x s1)
+               y = Timedesc.Span.succ x && OSeq.mem Timedesc.Span.equal x s1)
             r3
           && OSeq.for_all
             (fun (x, y) ->
@@ -60,7 +60,7 @@ let () =
                  @@ Seq_utils.last_element_of_seq r
                in
                y = Timedesc.Span.succ x
-               && OSeq.mem ~eq:Timedesc.Span.equal x s2
+               && OSeq.mem Timedesc.Span.equal x s2
                && not
                  (OSeq.exists Timedesc.Span.(fun x2 -> xr < x2 && x2 < x) s2))
             r4

--- a/fuzz/pattern_resolution_is_sound.ml
+++ b/fuzz/pattern_resolution_is_sound.ml
@@ -27,7 +27,7 @@ let timestamp_is_okay (tz : Timedesc.Time_zone.t) (pattern : Pattern.t)
     pattern.month_days
     |> Int_set.to_seq
     |> Seq.map (fun mday -> if mday < 0 then day_count + mday + 1 else mday)
-    |> OSeq.mem ~eq:( = ) (Timedesc.day dt)
+    |> OSeq.mem ( = ) (Timedesc.day dt)
   in
   let wday_is_fine =
     Weekday_set.is_empty pattern.weekdays

--- a/fuzz/resolver_is_same_as_simple_resolver.ml
+++ b/fuzz/resolver_is_same_as_simple_resolver.ml
@@ -18,7 +18,7 @@ let () =
   Crowbar.add_test ~name:"resolver_is_same_as_simple_resolver" [ time ]
     (fun t ->
        let r =
-         OSeq.equal ~eq:Time.Interval'.equal
+         OSeq.equal Time.Interval'.equal
            (CCResult.get_exn
             @@ Resolver.resolve
               Time.(inter [ t; intervals [ (search_start, search_end_exc) ] ])

--- a/fuzz/simple_resolver.ml
+++ b/fuzz/simple_resolver.ml
@@ -168,7 +168,7 @@ let aux_pattern_mem search_using_tz (pattern : Pattern.t) (timestamp : int64) :
     |> Int_set.to_seq
     |> Seq.map (fun mday -> if mday < 0 then day_count + mday + 1 else mday)
     |> Seq.filter (fun mday -> 1 <= mday && mday <= day_count)
-    |> OSeq.mem ~eq:( = ) (Timedesc.day dt)
+    |> OSeq.mem ( = ) (Timedesc.day dt)
   in
   let wday_is_fine =
     Weekday_set.is_empty pattern.weekdays

--- a/fuzz/union_is_sound_and_complete.ml
+++ b/fuzz/union_is_sound_and_complete.ml
@@ -12,7 +12,7 @@ let () =
           |> Time.Intervals.Union.union_multi_seq
           |> Time.slice_valid_interval
         in
-        let r = OSeq.equal ~eq:Time.Interval'.equal s s' in
+        let r = OSeq.equal Time.Interval'.equal s s' in
         if not r then
           Crowbar.fail
             (Fmt.str "tz: %s, times: %a\n"

--- a/fuzz/union_order_does_not_matter.ml
+++ b/fuzz/union_order_does_not_matter.ml
@@ -8,7 +8,7 @@ let () =
         let t2 = Time.union l2 in
         let r1 = CCResult.get_exn @@ Resolver.resolve t1 in
         let r2 = CCResult.get_exn @@ Resolver.resolve t2 in
-        let r = OSeq.equal ~eq:Time.Interval'.equal r1 r2 in
+        let r = OSeq.equal Time.Interval'.equal r1 r2 in
         if not r then
           Crowbar.fail
             (Fmt.str "rand: %d, l1: %a\nl2: %a\n" rand

--- a/timere-parse.opam
+++ b/timere-parse.opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "bisect_ppx" {dev & >= "2.5.0"}
   "dune" {>= "2.9"}
-  "oseq" {>= "0.3"}
+  "oseq" {>= "0.5"}
   "re" {>= "1.9.0"}
   "containers" {>= "3.6"}
   "timedesc" {>= "0.8.0"}

--- a/timere-tests/builder.ml
+++ b/timere-tests/builder.ml
@@ -37,7 +37,7 @@ let make_timestamp_intervals ~rng ~min_year ~max_year_inc =
       let start =
         make_date_time ~rng ~min_year ~max_year_inc
         |> Timedesc.to_timestamp
-        |> Timedesc.min_of_local_result
+        |> Timedesc.min_of_local_dt_result
       in
       let end_exc =
         Timedesc.Span.add start (Timedesc.Span.make ~ns:(rng ()) ())

--- a/timere-tests/time_intervals_tests.ml
+++ b/timere-tests/time_intervals_tests.ml
@@ -224,7 +224,7 @@ module Qc = struct
              ~not_mem_of:(CCList.to_seq not_mem_of) (CCList.to_seq mem_of)
          in
          Time.Intervals.Inter.inter (CCList.to_seq mem_of) res
-         |> OSeq.equal ~eq:Time.Interval'.equal res)
+         |> OSeq.equal Time.Interval'.equal res)
 
   let relative_complement_self =
     QCheck.Test.make ~count:10_000 ~name:"relative_complement_self"
@@ -237,7 +237,7 @@ module Qc = struct
       sorted_time_slots_maybe_gaps (fun l ->
           let s = l |> CCList.to_seq in
           let res = Time.Intervals.Inter.inter s s in
-          OSeq.equal ~eq:Time.Interval'.equal s res)
+          OSeq.equal Time.Interval'.equal s res)
 
   let inter_commutative =
     QCheck.Test.make ~count:10_000 ~name:"inter_commutative"
@@ -247,7 +247,7 @@ module Qc = struct
          let s2 = l2 |> CCList.to_seq in
          let inter1 = Time.Intervals.Inter.inter s1 s2 in
          let inter2 = Time.Intervals.Inter.inter s2 s1 in
-         OSeq.equal ~eq:Time.Interval'.equal inter1 inter2)
+         OSeq.equal Time.Interval'.equal inter1 inter2)
 
   let inter_associative =
     QCheck.Test.make ~count:10_000 ~name:"inter_associative"
@@ -260,14 +260,14 @@ module Qc = struct
          let s3 = l3 |> CCList.to_seq in
          let inter1 = Time.Intervals.Inter.(inter (inter s1 s2) s3) in
          let inter2 = Time.Intervals.Inter.(inter s1 (inter s2 s3)) in
-         OSeq.equal ~eq:Time.Interval'.equal inter1 inter2)
+         OSeq.equal Time.Interval'.equal inter1 inter2)
 
   let union_with_self =
     QCheck.Test.make ~count:10_000 ~name:"union_with_self"
       sorted_time_slots_with_gaps (fun l ->
           let s = l |> CCList.to_seq in
           let res = Time.Intervals.Union.union s s in
-          OSeq.equal ~eq:Time.Interval'.equal s res)
+          OSeq.equal Time.Interval'.equal s res)
 
   let union_commutative =
     QCheck.Test.make ~count:10_000 ~name:"union_commutative"
@@ -277,7 +277,7 @@ module Qc = struct
          let s2 = l2 |> CCList.to_seq in
          let inter1 = Time.Intervals.Union.union s1 s2 in
          let inter2 = Time.Intervals.Union.union s2 s1 in
-         OSeq.equal ~eq:Time.Interval'.equal inter1 inter2)
+         OSeq.equal Time.Interval'.equal inter1 inter2)
 
   let union_associative =
     QCheck.Test.make ~count:10_000 ~name:"union_associative"
@@ -290,7 +290,7 @@ module Qc = struct
          let s3 = l3 |> CCList.to_seq in
          let res1 = Time.Intervals.(Union.union (Union.union s1 s2) s3) in
          let res2 = Time.Intervals.(Union.union s1 (Union.union s2 s3)) in
-         OSeq.equal ~eq:Time.Interval'.equal res1 res2)
+         OSeq.equal Time.Interval'.equal res1 res2)
 
   let inter_union_distributive1 =
     QCheck.Test.make ~count:10_000 ~name:"inter_union_distributive1"
@@ -305,7 +305,7 @@ module Qc = struct
          let res2 =
            Time.Intervals.(Inter.inter (Union.union s1 s2) (Union.union s1 s3))
          in
-         OSeq.equal ~eq:Time.Interval'.equal res1 res2)
+         OSeq.equal Time.Interval'.equal res1 res2)
 
   let inter_union_distributive2 =
     QCheck.Test.make ~count:10_000 ~name:"inter_union_distributive2"
@@ -320,7 +320,7 @@ module Qc = struct
          let res2 =
            Time.Intervals.(Union.union (Inter.inter s1 s2) (Inter.inter s1 s3))
          in
-         OSeq.equal ~eq:Time.Interval'.equal res1 res2)
+         OSeq.equal Time.Interval'.equal res1 res2)
 
   let suite =
     [

--- a/timere.opam
+++ b/timere.opam
@@ -25,7 +25,7 @@ depends: [
   "bisect_ppx" {dev & >= "2.5.0"}
   "dune" {>= "2.9"}
   "seq"
-  "oseq" {>= "0.3"}
+  "oseq" {>= "0.5"}
   "containers" {>= "3.6"}
   "fmt"
   "timedesc" {>= "1.1.0"}

--- a/timere/time.ml
+++ b/timere/time.ml
@@ -878,7 +878,7 @@ let equal t1 t2 =
     match (t1, t2) with
     | Empty, Empty -> true
     | All, All -> true
-    | Intervals s1, Intervals s2 -> OSeq.equal ~eq:( = ) s1 s2
+    | Intervals s1, Intervals s2 -> OSeq.equal ( = ) s1 s2
     | ISO_week_pattern (y1, w1), ISO_week_pattern (y2, w2) ->
       Int_set.equal y1 y2 && Int_set.equal w1 w2
     | Pattern p1, Pattern p2 -> Pattern.equal p1 p2


### PR DESCRIPTION
This PR contains the necessary changes to use OSeq 0.5
The OSeq O.5 release contains breaking changes to its API, but not to its functionnality.
Another option would be to add an upper-bound in opam files